### PR TITLE
Day 5 Spring Security Authorization Test, Account UpdateProfile, UpdatePassword

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,10 +30,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
     implementation 'com.github.node-gradle:gradle-node-plugin:3.1.0'
+    implementation 'org.projectlombok:lombok'
 
 
 
-    compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -41,6 +41,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 node {
     version = '16.15.0'

--- a/src/main/java/com/guham/guham/account/AccountController.java
+++ b/src/main/java/com/guham/guham/account/AccountController.java
@@ -33,7 +33,7 @@ public class AccountController {
     }
 
     @PostMapping("/sign-up")
-    public String signUpSubmit(@Valid SignUpForm signUpForm, Errors errors) {
+    public String signUp(@Valid SignUpForm signUpForm, Errors errors) {
         if (errors.hasErrors()) {
             return "account/sign-up";
         }

--- a/src/main/java/com/guham/guham/account/AccountService.java
+++ b/src/main/java/com/guham/guham/account/AccountService.java
@@ -91,4 +91,9 @@ public class AccountService implements UserDetailsService {
         account.updateProfile(profile);
         accountRepository.save(account);
     }
+
+    public void updatePassword(Account account, String newPassword) {
+        account.updatePassword(passwordEncoder.encode(newPassword));
+        accountRepository.save(account);
+    }
 }

--- a/src/main/java/com/guham/guham/account/AccountService.java
+++ b/src/main/java/com/guham/guham/account/AccountService.java
@@ -3,6 +3,7 @@ package com.guham.guham.account;
 import com.guham.guham.domain.Account;
 import com.guham.guham.settings.Profile;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -16,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 
 @Service
@@ -88,12 +90,14 @@ public class AccountService implements UserDetailsService {
     }
 
     public void updateProfile(Account account, Profile profile) {
-        account.updateProfile(profile);
-        accountRepository.save(account);
+        Account findAccount = accountRepository.findById(account.getId())
+                .orElseThrow(EntityNotFoundException::new);
+        findAccount.updateProfile(profile);
     }
 
     public void updatePassword(Account account, String newPassword) {
-        account.updatePassword(passwordEncoder.encode(newPassword));
-        accountRepository.save(account);
+        Account findAccount = accountRepository.findById(account.getId())
+                .orElseThrow(EntityNotFoundException::new);
+        findAccount.updatePassword(passwordEncoder.encode(newPassword));
     }
 }

--- a/src/main/java/com/guham/guham/domain/Account.java
+++ b/src/main/java/com/guham/guham/domain/Account.java
@@ -82,6 +82,6 @@ public class Account {
     }
 
     public void updatePassword(String newPassword) {
-
+        this.password = newPassword;
     }
 }

--- a/src/main/java/com/guham/guham/domain/Account.java
+++ b/src/main/java/com/guham/guham/domain/Account.java
@@ -40,7 +40,7 @@ public class Account {
     private String location;
     @Lob
     @Basic(fetch = FetchType.EAGER)
-    private String profileImage;
+    private String profileImage; // HTML DATA URL
 
     private boolean studyCreatedByEmail;
 
@@ -79,5 +79,9 @@ public class Account {
         this.occupation = profile.getOccupation();
         this.location = profile.getLocation();
         this.profileImage = profile.getProfileImage();
+    }
+
+    public void updatePassword(String newPassword) {
+
     }
 }

--- a/src/main/java/com/guham/guham/domain/Account.java
+++ b/src/main/java/com/guham/guham/domain/Account.java
@@ -78,5 +78,6 @@ public class Account {
         this.url = profile.getUrl();
         this.occupation = profile.getOccupation();
         this.location = profile.getLocation();
+        this.profileImage = profile.getProfileImage();
     }
 }

--- a/src/main/java/com/guham/guham/settings/PasswordForm.java
+++ b/src/main/java/com/guham/guham/settings/PasswordForm.java
@@ -1,0 +1,13 @@
+package com.guham.guham.settings;
+
+import lombok.Data;
+import org.hibernate.validator.constraints.Length;
+
+@Data
+public class PasswordForm {
+    @Length(min = 8, max = 50)
+    private String newPassword;
+
+    @Length(min = 8, max = 50)
+    private String newPasswordConfirm;
+}

--- a/src/main/java/com/guham/guham/settings/PasswordFormValidator.java
+++ b/src/main/java/com/guham/guham/settings/PasswordFormValidator.java
@@ -1,0 +1,19 @@
+package com.guham.guham.settings;
+
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+public class PasswordFormValidator implements Validator {
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return PasswordForm.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        PasswordForm passwordForm = (PasswordForm) target;
+        if(!passwordForm.getNewPassword().equals(passwordForm.getNewPasswordConfirm())){
+            errors.rejectValue("newPassword", "wrong.value","입력한 새 패스워드가 일치하지 않습니다");
+        }
+    }
+}

--- a/src/main/java/com/guham/guham/settings/Profile.java
+++ b/src/main/java/com/guham/guham/settings/Profile.java
@@ -20,10 +20,13 @@ public class Profile {
     @Length(max = 50)
     private String location;
 
+    private String profileImage;
+
     public Profile(Account account) {
         this.bio = account.getBio();
         this.url = account.getUrl();
         this.occupation = account.getOccupation();
         this.location = account.getLocation();
+        this.profileImage = account.getProfileImage();
     }
 }

--- a/src/main/java/com/guham/guham/settings/Profile.java
+++ b/src/main/java/com/guham/guham/settings/Profile.java
@@ -3,13 +3,21 @@ package com.guham.guham.settings;
 import com.guham.guham.domain.Account;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 @Data
 @NoArgsConstructor
 public class Profile {
+    @Length(max = 35)
     private String bio;
+
+    @Length(max = 50)
     private String url;
+
+    @Length(max = 50)
     private String occupation;
+
+    @Length(max = 50)
     private String location;
 
     public Profile(Account account) {

--- a/src/main/java/com/guham/guham/settings/SettingsController.java
+++ b/src/main/java/com/guham/guham/settings/SettingsController.java
@@ -18,8 +18,8 @@ import java.net.URL;
 @Controller
 @RequiredArgsConstructor
 public class SettingsController {
-    private static final String SETTINGS_PROFILE_VIEW_NAME = "settings/profile";
-    private static final String SETTINGS_PROFILE_URL = "/settings/profile";
+    static final String SETTINGS_PROFILE_VIEW_NAME = "settings/profile";
+    static final String SETTINGS_PROFILE_URL = "/settings/profile";
 
     private final AccountService accountService;
 

--- a/src/main/java/com/guham/guham/settings/SettingsController.java
+++ b/src/main/java/com/guham/guham/settings/SettingsController.java
@@ -7,24 +7,34 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.Errors;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.validation.Valid;
-import java.net.URL;
 
 @Controller
 @RequiredArgsConstructor
 public class SettingsController {
+
     static final String SETTINGS_PROFILE_VIEW_NAME = "settings/profile";
     static final String SETTINGS_PROFILE_URL = "/settings/profile";
+
+    static final String SETTINGS_PASSWORD_VIEW_NAME = "settings/password";
+    static final String SETTINGS_PASSWORD_URL = "/settings/password";
+
+    @InitBinder("passwordForm")
+    public void initBinder(WebDataBinder webDataBinder) {
+        webDataBinder.addValidators(new PasswordFormValidator());
+    }
 
     private final AccountService accountService;
 
     @GetMapping(SETTINGS_PROFILE_URL)
-    public String profileUpdateForm(@CurrentAccount Account account, Model model){
+    public String updateProfileForm(@CurrentAccount Account account, Model model){
         model.addAttribute(account);
         model.addAttribute(new Profile(account));
         return SETTINGS_PROFILE_VIEW_NAME;
@@ -41,5 +51,25 @@ public class SettingsController {
         accountService.updateProfile(account, profile);
         attributes.addFlashAttribute("message", "프로필 수정했습니다.");
         return "redirect:" + SETTINGS_PROFILE_URL;
+    }
+
+    @GetMapping(SETTINGS_PASSWORD_URL)
+    public String updatePasswordForm(@CurrentAccount Account account, Model model){
+        model.addAttribute(account);
+        model.addAttribute(new PasswordForm());
+        return SETTINGS_PASSWORD_VIEW_NAME;
+    }
+
+    @PostMapping(SETTINGS_PASSWORD_URL)
+    public String updatePassword(@CurrentAccount Account account, @Valid PasswordForm passwordForm,
+                                 Errors errors, Model model, RedirectAttributes attributes){
+        if(errors.hasErrors()){
+            model.addAttribute(account);
+            return SETTINGS_PASSWORD_VIEW_NAME;
+        }
+
+        accountService.updatePassword(account, passwordForm.getNewPassword());
+        attributes.addFlashAttribute("message", "패스워드 변경했습니다.");
+        return "redirect:" + SETTINGS_PASSWORD_URL;
     }
 }

--- a/src/main/resources/static/package-lock.json
+++ b/src/main/resources/static/package-lock.json
@@ -10,9 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "bootstrap": "^4.4.1",
+        "cropper": "^4.1.0",
         "font-awesome": "^4.7.0",
         "jdenticon": "^2.2.0",
-        "jquery": "^3.4.1"
+        "jquery": "^3.4.1",
+        "jquery-cropper": "^1.0.1"
       }
     },
     "node_modules/@types/node": {
@@ -41,6 +43,22 @@
       "resolved": "https://registry.npmjs.org/canvas-renderer/-/canvas-renderer-2.1.1.tgz",
       "integrity": "sha512-/V0XetN7s1Mk3NO7x2wxPZYv0pLMQtGAhecuOuKR88beiYCUle1AbCcFZNLu+4NVzi9RVHS0rXtIgzPEaKidLw=="
     },
+    "node_modules/cropper": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cropper/-/cropper-4.1.0.tgz",
+      "integrity": "sha512-dNbkWNT606oMgRQ2aYMerDnPpSVLBMTWyERDHsDwih1ahJiVpyfSM9ev/n6G4ElfRG8t0shUZ5FXLg7YtmDdBQ==",
+      "dependencies": {
+        "cropperjs": "^1.5.6"
+      },
+      "peerDependencies": {
+        "jquery": ">=1.9.1"
+      }
+    },
+    "node_modules/cropperjs": {
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/cropperjs/-/cropperjs-1.5.13.tgz",
+      "integrity": "sha512-by7jKAo73y5/Do0K6sxdTKHgndY0NMjG2bEdgeJxycbcmHuCiMXqw8sxy5C5Y5WTOTcDGmbT7Sr5CgKOXR06OA=="
+    },
     "node_modules/font-awesome": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
@@ -65,6 +83,15 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
       "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+    },
+    "node_modules/jquery-cropper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jquery-cropper/-/jquery-cropper-1.0.1.tgz",
+      "integrity": "sha512-KGlY8b0IJQi2Bxe3lqMKmd5Z2Ce4GrnDE5O8Iciza9xCzXISkL6EqX/jFHwnLL1H6Q4FGjoRguuv3lxezsbKJQ==",
+      "peerDependencies": {
+        "cropperjs": ">=1.0.0",
+        "jquery": ">=1.9.1"
+      }
     },
     "node_modules/popper.js": {
       "version": "1.16.1",

--- a/src/main/resources/static/package.json
+++ b/src/main/resources/static/package.json
@@ -10,8 +10,10 @@
   "license": "ISC",
   "dependencies": {
     "bootstrap": "^4.4.1",
+    "cropper": "^4.1.0",
     "font-awesome": "^4.7.0",
     "jdenticon": "^2.2.0",
-    "jquery": "^3.4.1"
+    "jquery": "^3.4.1",
+    "jquery-cropper": "^1.0.1"
   }
 }

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -52,8 +52,10 @@
       <li class="nav-item dropdown" sec:authorize="isAuthenticated()">
         <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-toggle="dropdown"
            aria-haspopup="true" aria-expanded="false">
-          <svg data-jdenticon-value="user127" th:data-jdenticon-value="${#authentication.name}"
+          <svg th:if="${#strings.isEmpty(account?.profileImage)}" th:data-jdenticon-value="${#authentication.name}"
                width="24" height="24" class="rounded border bg-light"></svg>
+          <img th:if="${!#strings.isEmpty(account?.profileImage)}" th:src="${account.profileImage}"
+               width="24" height="24" class="rounded border"/>
         </a>
         <div class="dropdown-menu dropdown-menu-sm-right" aria-labelledby="userDropdown">
           <h6 class="dropdown-header">

--- a/src/main/resources/templates/settings/password.html
+++ b/src/main/resources/templates/settings/password.html
@@ -8,7 +8,7 @@
 <div class="container">
   <div class="row mt-5 justify-content-center">
     <div class="col-2">
-      <div th:replace="fragments::settings-menu(currentMenu='profile')"></div>
+      <div th:replace="fragments::settings-menu(currentMenu='password')"></div>
 
     </div>
     <div class="col-8">

--- a/src/main/resources/templates/settings/password.html
+++ b/src/main/resources/templates/settings/password.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head th:replace="fragments::head">
+</head>
+<body class="bg-light">
+<div th:replace="fragments::main-nav"></div>
+
+<div class="container">
+  <div class="row mt-5 justify-content-center">
+    <div class="col-2">
+      <div th:replace="fragments::settings-menu(currentMenu='profile')"></div>
+
+    </div>
+    <div class="col-8">
+
+      <div th:if="${message}" class="alert alert-info alert-dismissible fade show mt-3" role="alert">
+        <span th:text="${message}">메시지</span>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+
+      <div class="row">
+        <h2 class="col-sm-12">패스워드 변경</h2>
+      </div>
+      <div class="row mt-3">
+        <form class="needs-validation col-12" th:action="@{/settings/password}"
+              th:object="${passwordForm}" method="post" novalidate>
+          <div class="form-group">
+            <label for="newPassword">새 패스워드</label>
+            <input id="newPassword" type="password" th:field="*{newPassword}" class="form-control"
+                   aria-describedby="newPasswordHelp" required min="8" max="50">
+            <small id="newPasswordHelp" class="form-text text-muted">
+              새 패스워드를 입력하세요.
+            </small>
+            <small class="invalid-feedback">패스워드를 입력하세요.</small>
+            <small class="form-text text-danger" th:if="${#fields.hasErrors('newPassword')}" th:errors="*{newPassword}">New Password Error</small>
+          </div>
+
+          <div class="form-group">
+            <label for="newPasswordConfirm">새 패스워드 확인</label>
+            <input id="newPasswordConfirm" type="password" th:field="*{newPasswordConfirm}" class="form-control"
+                   aria-describedby="newPasswordConfirmHelp" required min="8" max="50">
+            <small id="newPasswordConfirmHelp" class="form-text text-muted">
+              새 패스워드를 다시 한번 입력하세요.
+            </small>
+            <small class="invalid-feedback">새 패스워드를 다시 입력하세요.</small>
+            <small class="form-text text-danger" th:if="${#fields.hasErrors('newPasswordConfirm')}" th:errors="*{newPasswordConfirm}">New Password Confirm Error</small>
+          </div>
+
+          <div class="form-group">
+            <button class="btn btn-outline-primary" type="submit" aria-describedby="submitHelp">패스워드 변경하기</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+<script th:replace="fragments::form-validation"></script>
+
+</body>
+</html>

--- a/src/main/resources/templates/settings/profile.html
+++ b/src/main/resources/templates/settings/profile.html
@@ -68,9 +68,9 @@
             </small>
           </div>
 
-<!--          <div class="form-group">-->
-<!--            <input id="profileImage" type="hidden" th:field="*{profileImage}" class="form-control" />-->
-<!--          </div>-->
+          <div class="form-group">
+            <input id="profileImage" type="hidden" th:field="*{profileImage}" class="form-control" />
+          </div>
 
           <div class="form-group">
             <button class="btn btn-primary btn-block" type="submit"
@@ -78,10 +78,127 @@
           </div>
 
         </form>
+
+        <div class="col-sm-6">
+          <div class="card text-center">
+            <div class="card-header">
+              프로필 이미지
+            </div>
+            <div id="current-profile-image" class="mt-3">
+              <svg th:if="${#strings.isEmpty(profile.profileImage)}" class="rounded"
+                   th:data-jdenticon-value="${account.nickname}" width="125" height="125"></svg>
+              <img th:if="${!#strings.isEmpty(profile.profileImage)}" class="rounded"
+                   th:src="${profile.profileImage}"
+                   width="125" height="125" alt="name" th:alt="${account.nickname}"/>
+            </div>
+            <div id="new-profile-image" class="mt-3"></div>
+            <div class="card-body">
+              <div class="custom-file">
+                <input type="file" class="custom-file-input" id="profile-image-file">
+                <label class="custom-file-label" for="profile-image-file">프로필 이미지 변경</label>
+              </div>
+              <div id="new-profile-image-control" class="mt-3">
+                <button class="btn btn-outline-primary btn-block" id="cut-button">자르기</button>
+                <button class="btn btn-outline-success btn-block" id="confirm-button">확인</button>
+                <button class="btn btn-outline-warning btn-block" id="reset-button">취소</button>
+              </div>
+              <div id="cropped-new-profile-image" class="mt-3"></div>
+            </div>
+          </div>
+        </div>
+
       </div>
+
+
     </div>
   </div>
 </div>
-<script th:replace="fragments::form-validation"></script>
+<link  href="/node_modules/cropper/dist/cropper.min.css" rel="stylesheet">
+<script src="/node_modules/cropper/dist/cropper.min.js"></script>
+<script src="/node_modules/jquery-cropper/dist/jquery-cropper.min.js"></script>
+<script type="application/javascript">
+  $(function(){
+    cropper = '';
+    let $confirmBtn = $("#confirm-button");
+    let $resetBtn = $("#reset-button");
+    let $cutBtn = $("#cut-button");
+    let $newProfileImage = $("#new-profile-image");
+    let $currentProfileImage = $("#current-profile-image");
+    let $resultImage = $("#cropped-new-profile-image");
+    let $profileImage = $("#profileImage");
+
+    $newProfileImage.hide();
+    $cutBtn.hide();
+    $resetBtn.hide();
+    $confirmBtn.hide();
+
+    $("#profile-image-file").change(function(e) {
+      if (e.target.files.length === 1) {
+        const reader = new FileReader();
+        reader.onload = e => {
+          if (e.target.result) {
+            if (!e.target.result.startsWith("data:image")) {
+              alert("이미지 파일을 선택하세요.");
+              return;
+            }
+
+            let img = document.createElement("img");
+            img.id = 'new-profile';
+            img.src = e.target.result;
+            img.setAttribute('width', '100%');
+
+            $newProfileImage.html(img);
+            $newProfileImage.show();
+            $currentProfileImage.hide();
+
+            let $newImage = $(img);
+            $newImage.cropper({aspectRatio: 1});
+            cropper = $newImage.data('cropper');
+
+            $cutBtn.show();
+            $confirmBtn.hide();
+            $resetBtn.show();
+          }
+        };
+
+        reader.readAsDataURL(e.target.files[0]);
+      }
+    });
+
+    $resetBtn.click(function() {
+      $currentProfileImage.show();
+      $newProfileImage.hide();
+      $resultImage.hide();
+      $resetBtn.hide();
+      $cutBtn.hide();
+      $confirmBtn.hide();
+      $profileImage.val('');
+    });
+
+    $cutBtn.click(function () {
+      let dataUrl = cropper.getCroppedCanvas().toDataURL();
+
+      // if (dataUrl.length > 1000 * 1024) {
+      //   alert("이미지 파일이 너무 큽니다. 1024000 보다 작은 파일을 사용하세요. 현재 이미지 사이즈 " + dataUrl.length);
+      //   return;
+      // }
+
+      let newImage = document.createElement("img");
+      newImage.id = "cropped-new-profile-image";
+      newImage.src = dataUrl;
+      newImage.width = 125;
+      $resultImage.html(newImage);
+      $resultImage.show();
+      $confirmBtn.show();
+
+      $confirmBtn.click(function () {
+        $newProfileImage.html(newImage);
+        $cutBtn.hide();
+        $confirmBtn.hide();
+        $profileImage.val(dataUrl);
+      });
+    });
+  });
+</script>
 </body>
 </html>

--- a/src/test/java/com/guham/guham/WithAccount.java
+++ b/src/test/java/com/guham/guham/WithAccount.java
@@ -8,6 +8,5 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithAccountSecurityContextFactory.class)
 public @interface WithAccount {
-
     String value();
 }

--- a/src/test/java/com/guham/guham/WithAccount.java
+++ b/src/test/java/com/guham/guham/WithAccount.java
@@ -1,0 +1,13 @@
+package com.guham.guham;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithAccountSecurityContextFactory.class)
+public @interface WithAccount {
+
+    String value();
+}

--- a/src/test/java/com/guham/guham/WithAccountSecurityContextFactory.java
+++ b/src/test/java/com/guham/guham/WithAccountSecurityContextFactory.java
@@ -1,0 +1,38 @@
+package com.guham.guham;
+
+import com.guham.guham.account.AccountService;
+import com.guham.guham.account.SignUpForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.lang.annotation.Annotation;
+
+@RequiredArgsConstructor
+public class WithAccountSecurityContextFactory implements WithSecurityContextFactory<WithAccount> {
+    private final AccountService accountService;
+
+    @Override
+    public SecurityContext createSecurityContext(WithAccount withAccount) {
+        String nickname = withAccount.value();
+
+        SignUpForm signUpForm = new SignUpForm();
+        signUpForm.setNickname(nickname);
+        signUpForm.setEmail("email@email.com");
+        signUpForm.setPassword("1q2w3e4r");
+        accountService.signUp(signUpForm);
+
+        UserDetails principal = accountService.loadUserByUsername(nickname);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal,
+                principal.getPassword(), principal.getAuthorities());
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        context.setAuthentication(authentication);
+        return context;
+    }
+}

--- a/src/test/java/com/guham/guham/settings/SettingsControllerTest.java
+++ b/src/test/java/com/guham/guham/settings/SettingsControllerTest.java
@@ -3,14 +3,19 @@ package com.guham.guham.settings;
 import com.guham.guham.WithAccount;
 import com.guham.guham.account.AccountRepository;
 import com.guham.guham.account.AccountService;
+import com.guham.guham.account.SignUpForm;
 import com.guham.guham.domain.Account;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Set;
@@ -30,7 +35,8 @@ class SettingsControllerTest {
 
     @Autowired
     PasswordEncoder passwordEncoder;
-
+    @Autowired
+    AccountService accountService;
     @Autowired
     AccountRepository accountRepository;
 
@@ -97,7 +103,7 @@ class SettingsControllerTest {
     @DisplayName("패스워드 수정 - 입력값 정상")
     @WithAccount("bebe")
     public void updatePassword() throws Exception {
-        String newPassword = "1q2w3e4r";
+        String newPassword = "1234qwer";
         mockMvc.perform(post(SETTINGS_PASSWORD_URL)
                         .param("newPassword", newPassword)
                         .param("newPasswordConfirm",newPassword)

--- a/src/test/java/com/guham/guham/settings/SettingsControllerTest.java
+++ b/src/test/java/com/guham/guham/settings/SettingsControllerTest.java
@@ -1,0 +1,83 @@
+package com.guham.guham.settings;
+
+import com.guham.guham.WithAccount;
+import com.guham.guham.account.AccountRepository;
+import com.guham.guham.account.AccountService;
+import com.guham.guham.domain.Account;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Set;
+
+import static com.guham.guham.settings.SettingsController.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SettingsControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+
+    @Autowired
+    AccountRepository accountRepository;
+
+    @AfterEach
+    public void afterEach(){
+        accountRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("프로필 수정 폼")
+    @WithAccount("bebe")
+    public void updateProfileForm() throws Exception {
+        mockMvc.perform(get(SETTINGS_PROFILE_URL))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("account", "profile"));
+    }
+
+    @Test
+    @DisplayName("프로필 수정 - 입력값 정상")
+    @WithAccount("bebe")
+    public void updateProfile() throws Exception {
+        String changeBio = "짧은 소개";
+        mockMvc.perform(post(SETTINGS_PROFILE_URL)
+                        .param("bio", changeBio)
+                        .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl(SETTINGS_PROFILE_URL))
+                .andExpect(flash().attributeExists("message"));
+
+        Account bebe = accountRepository.findByNickname("bebe");
+        assertEquals(changeBio, bebe.getBio());
+    }
+
+    @Test
+    @DisplayName("프로필 수정 - 입력값 오류")
+    @WithAccount("bebe")
+    public void updateProfileWithWrongInput() throws Exception {
+        String changeBio = "too long too long too long too long " +
+                "too long too long too long too long too long" +
+                " too long too long too long";
+
+        mockMvc.perform(post(SETTINGS_PROFILE_URL)
+                        .param("bio", changeBio)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(view().name(SETTINGS_PROFILE_VIEW_NAME))
+                .andExpect(model().hasErrors())
+                .andExpect(model().attributeExists("account","profile"));
+
+        Account bebe = accountRepository.findByNickname("bebe");
+        assertNull(bebe.getBio());
+    }
+}


### PR DESCRIPTION
기능구현
1. Authorization Test를 위한 커스텀 어노테이션 @WithAccount 구현
2. Account UpdateProfile 구현, Cropper JS로 Front 구현
3. Account UpdatePassword 구현, PasswordValidator 구현
4. Account Update시 JPA Merger -> Dirty Cheking 변경

[블로그 정리](https://anythingis.tistory.com/149)