### PR TITLE
Dev-007-update_nickname, Detached Entity Sync

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,6 @@ dependencies {
     implementation 'com.github.node-gradle:gradle-node-plugin:3.1.0'
     implementation 'org.projectlombok:lombok'
 
-
-
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/guham/guham/account/AccountRepository.java
+++ b/src/main/java/com/guham/guham/account/AccountRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
-public interface AccountRepository extends JpaRepository<Account, Long> {
+public interface AccountRepository extends JpaRepository<Account, java.lang.Long> {
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
 

--- a/src/main/java/com/guham/guham/account/AccountService.java
+++ b/src/main/java/com/guham/guham/account/AccountService.java
@@ -1,8 +1,8 @@
 package com.guham.guham.account;
 
 import com.guham.guham.domain.Account;
-import com.guham.guham.settings.Notifications;
-import com.guham.guham.settings.Profile;
+import com.guham.guham.settings.form.Notifications;
+import com.guham.guham.settings.form.Profile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;

--- a/src/main/java/com/guham/guham/account/AccountService.java
+++ b/src/main/java/com/guham/guham/account/AccountService.java
@@ -4,6 +4,7 @@ import com.guham.guham.domain.Account;
 import com.guham.guham.settings.Notifications;
 import com.guham.guham.settings.Profile;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -27,7 +28,9 @@ import java.util.List;
 @Transactional
 public class AccountService implements UserDetailsService {
     private final AccountRepository accountRepository;
+
     private final JavaMailSender javaMailSender;
+
     private final PasswordEncoder passwordEncoder;
 
 

--- a/src/main/java/com/guham/guham/account/AccountService.java
+++ b/src/main/java/com/guham/guham/account/AccountService.java
@@ -4,14 +4,11 @@ import com.guham.guham.domain.Account;
 import com.guham.guham.settings.Notifications;
 import com.guham.guham.settings.Profile;
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
-import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -90,34 +87,41 @@ public class AccountService implements UserDetailsService {
         logIn(account);
     }
 
-    private void syncAuthenticationAccount(Account account){
+    private void syncAuthenticationAccount(Account accountId){
         Authentication token = new UsernamePasswordAuthenticationToken(
-                new UserAccount(account),
-                account.getPassword(),
+                new UserAccount(accountId),
+                accountId.getPassword(),
                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
         SecurityContextHolder.getContext().setAuthentication(token);
     }
 
 
-    public void updateProfile(Account account, Profile profile) {
-        Account findAccount = accountRepository.findById(account.getId())
+    public void updateProfile(Long accountId, Profile profile) {
+        Account findAccount = accountRepository.findById(accountId)
                 .orElseThrow(EntityNotFoundException::new);
         findAccount.updateProfile(profile);
         syncAuthenticationAccount(findAccount);
     }
 
-    public void updatePassword(Account account, String newPassword) {
-        Account findAccount = accountRepository.findById(account.getId())
+    public void updatePassword(Long accountId, String newPassword) {
+        Account findAccount = accountRepository.findById(accountId)
                 .orElseThrow(EntityNotFoundException::new);
         findAccount.updatePassword(passwordEncoder.encode(newPassword));
         syncAuthenticationAccount(findAccount);
     }
 
-    public void updateNotifications(Account account, Notifications notifications) {
-        Account findAccount = accountRepository.findById(account.getId())
+    public void updateNotifications(Long accountId, Notifications notifications) {
+        Account findAccount = accountRepository.findById(accountId)
                 .orElseThrow(EntityNotFoundException::new);
         findAccount.updateNotifications(notifications);
+        syncAuthenticationAccount(findAccount);
+    }
+
+    public void updateNickname(Long accountId, String nickname){
+        Account findAccount = accountRepository.findById(accountId)
+                .orElseThrow(EntityNotFoundException::new);
+        findAccount.updateNickname(nickname);
         syncAuthenticationAccount(findAccount);
     }
 }

--- a/src/main/java/com/guham/guham/account/AccountService.java
+++ b/src/main/java/com/guham/guham/account/AccountService.java
@@ -87,10 +87,10 @@ public class AccountService implements UserDetailsService {
         logIn(account);
     }
 
-    private void syncAuthenticationAccount(Account accountId){
+    private void syncAuthenticationAccount(Account account){
         Authentication token = new UsernamePasswordAuthenticationToken(
-                new UserAccount(accountId),
-                accountId.getPassword(),
+                new UserAccount(account),
+                account.getPassword(),
                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
 
         SecurityContextHolder.getContext().setAuthentication(token);

--- a/src/main/java/com/guham/guham/config/AppConfig.java
+++ b/src/main/java/com/guham/guham/config/AppConfig.java
@@ -1,5 +1,6 @@
 package com.guham.guham.config;
 
+import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
@@ -12,4 +13,5 @@ public class AppConfig {
     public PasswordEncoder passwordEncoder(){
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
+
 }

--- a/src/main/java/com/guham/guham/config/AppConfig.java
+++ b/src/main/java/com/guham/guham/config/AppConfig.java
@@ -1,6 +1,5 @@
 package com.guham.guham.config;
 
-import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;

--- a/src/main/java/com/guham/guham/domain/Account.java
+++ b/src/main/java/com/guham/guham/domain/Account.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 public class Account {
     @Id
     @GeneratedValue
-    private Long id;
+    private java.lang.Long id;
     @Column(unique = true)
     private String email;
 

--- a/src/main/java/com/guham/guham/domain/Account.java
+++ b/src/main/java/com/guham/guham/domain/Account.java
@@ -94,4 +94,8 @@ public class Account {
         this.studyUpdatedByWeb = notifications.isStudyUpdatedByWeb();
         this.studyUpdatedByEmail = notifications.isStudyUpdatedByEmail();
     }
+
+    public void updateNickname(String nickname){
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/guham/guham/domain/Account.java
+++ b/src/main/java/com/guham/guham/domain/Account.java
@@ -1,7 +1,7 @@
 package com.guham.guham.domain;
 
-import com.guham.guham.settings.Notifications;
-import com.guham.guham.settings.Profile;
+import com.guham.guham.settings.form.Notifications;
+import com.guham.guham.settings.form.Profile;
 import lombok.*;
 
 import javax.persistence.*;

--- a/src/main/java/com/guham/guham/settings/SettingsController.java
+++ b/src/main/java/com/guham/guham/settings/SettingsController.java
@@ -2,13 +2,8 @@ package com.guham.guham.settings;
 
 import com.guham.guham.account.AccountService;
 import com.guham.guham.account.CurrentAccount;
-import com.guham.guham.account.UserAccount;
 import com.guham.guham.domain.Account;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.Errors;
@@ -20,7 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import javax.validation.Valid;
-import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -61,7 +55,7 @@ public class SettingsController {
             return SETTINGS_PROFILE_VIEW_NAME;
         }
 
-        accountService.updateProfile(account, profile);
+        accountService.updateProfile(account.getId(), profile);
         attributes.addFlashAttribute("message", "프로필 수정했습니다.");
         return "redirect:" + SETTINGS_PROFILE_URL;
     }
@@ -81,7 +75,7 @@ public class SettingsController {
             return SETTINGS_PASSWORD_VIEW_NAME;
         }
 
-        accountService.updatePassword(account, passwordForm.getNewPassword());
+        accountService.updatePassword(account.getId(), passwordForm.getNewPassword());
         attributes.addFlashAttribute("message", "패스워드 변경했습니다.");
         return "redirect:" + SETTINGS_PASSWORD_URL;
     }
@@ -101,7 +95,7 @@ public class SettingsController {
             return SETTINGS_NOTIFICATIONS_VIEW_NAME;
         }
 
-        accountService.updateNotifications(account, notifications);
+        accountService.updateNotifications(account.getId(), notifications);
         attributes.addFlashAttribute("message", "알림 설정을 변경했습니다.");
         return "redirect:" + SETTINGS_NOTIFICATIONS_URL;
     }

--- a/src/main/java/com/guham/guham/settings/SettingsController.java
+++ b/src/main/java/com/guham/guham/settings/SettingsController.java
@@ -3,6 +3,7 @@ package com.guham.guham.settings;
 import com.guham.guham.account.AccountService;
 import com.guham.guham.account.CurrentAccount;
 import com.guham.guham.domain.Account;
+import com.guham.guham.settings.form.NicknameForm;
 import com.guham.guham.settings.form.Notifications;
 import com.guham.guham.settings.form.PasswordForm;
 import com.guham.guham.settings.form.Profile;
@@ -112,6 +113,24 @@ public class SettingsController {
         return "redirect:" + SETTINGS_NOTIFICATIONS_URL;
     }
 
+    @GetMapping(SETTINGS_ACCOUNT_URL)
+    public String updateAccountForm(@CurrentAccount Account account, Model model) {
+        model.addAttribute(account);
+        model.addAttribute(new NicknameForm(account));
+        return SETTINGS_ACCOUNT_VIEW_NAME;
+    }
 
+    @PostMapping(SETTINGS_ACCOUNT_URL)
+    public String updateAccount(@CurrentAccount Account account, @Valid NicknameForm nicknameForm, Errors errors,
+                                Model model, RedirectAttributes attributes) {
+        if (errors.hasErrors()) {
+            model.addAttribute(account);
+            return SETTINGS_ACCOUNT_VIEW_NAME;
+        }
+
+        accountService.updateNickname(account.getId(), nicknameForm.getNickname());
+        attributes.addFlashAttribute("message", "닉네임을 수정했습니다.");
+        return "redirect:" + SETTINGS_ACCOUNT_URL;
+    }
 
 }

--- a/src/main/java/com/guham/guham/settings/SettingsController.java
+++ b/src/main/java/com/guham/guham/settings/SettingsController.java
@@ -3,6 +3,11 @@ package com.guham.guham.settings;
 import com.guham.guham.account.AccountService;
 import com.guham.guham.account.CurrentAccount;
 import com.guham.guham.domain.Account;
+import com.guham.guham.settings.form.Notifications;
+import com.guham.guham.settings.form.PasswordForm;
+import com.guham.guham.settings.form.Profile;
+import com.guham.guham.settings.validator.NicknameFormValidator;
+import com.guham.guham.settings.validator.PasswordFormValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -21,27 +26,34 @@ import javax.validation.Valid;
 public class SettingsController {
 
     static final String SETTINGS_PROFILE_VIEW_NAME = "settings/profile";
-
-    static final String SETTINGS_PROFILE_URL = "/settings/profile";
+    static final String SETTINGS_PROFILE_URL = "/" + SETTINGS_PROFILE_VIEW_NAME;
 
     static final String SETTINGS_PASSWORD_VIEW_NAME = "settings/password";
-
-    static final String SETTINGS_PASSWORD_URL = "/settings/password";
+    static final String SETTINGS_PASSWORD_URL = "/" + SETTINGS_PASSWORD_VIEW_NAME;
 
     static final String SETTINGS_NOTIFICATIONS_VIEW_NAME = "settings/notifications";
+    static final String SETTINGS_NOTIFICATIONS_URL = "/" + SETTINGS_NOTIFICATIONS_VIEW_NAME;
 
-    static final String SETTINGS_NOTIFICATIONS_URL = "/settings/notifications";
+    static final String SETTINGS_ACCOUNT_VIEW_NAME = "settings/account";
+    static final String SETTINGS_ACCOUNT_URL = "/" + SETTINGS_ACCOUNT_VIEW_NAME;
 
     private final AccountService accountService;
+    private final NicknameFormValidator nicknameFormValidator;
+
 
     @InitBinder("passwordForm")
-    public void initBinder(WebDataBinder webDataBinder) {
+    public void initBinderPassword(WebDataBinder webDataBinder) {
         webDataBinder.addValidators(new PasswordFormValidator());
+    }
+
+    @InitBinder("nicknameForm")
+    public void initBinderNickname(WebDataBinder webDataBinder){
+        webDataBinder.addValidators(nicknameFormValidator);
     }
 
 
     @GetMapping(SETTINGS_PROFILE_URL)
-    public String updateProfileForm(@CurrentAccount Account account, Model model){
+    public String updateProfileForm(@CurrentAccount Account account, Model model) {
         model.addAttribute(account);
         model.addAttribute(new Profile(account));
         return SETTINGS_PROFILE_VIEW_NAME;
@@ -49,8 +61,8 @@ public class SettingsController {
 
     @PostMapping(SETTINGS_PROFILE_URL)
     public String updateProfile(@CurrentAccount Account account, @Valid @ModelAttribute Profile profile,
-                                Errors errors, Model model, RedirectAttributes attributes){
-        if(errors.hasErrors()){
+                                Errors errors, Model model, RedirectAttributes attributes) {
+        if (errors.hasErrors()) {
             model.addAttribute(account);
             return SETTINGS_PROFILE_VIEW_NAME;
         }
@@ -61,7 +73,7 @@ public class SettingsController {
     }
 
     @GetMapping(SETTINGS_PASSWORD_URL)
-    public String updatePasswordForm(@CurrentAccount Account account, Model model){
+    public String updatePasswordForm(@CurrentAccount Account account, Model model) {
         model.addAttribute(account);
         model.addAttribute(new PasswordForm());
         return SETTINGS_PASSWORD_VIEW_NAME;
@@ -69,8 +81,8 @@ public class SettingsController {
 
     @PostMapping(SETTINGS_PASSWORD_URL)
     public String updatePassword(@CurrentAccount Account account, @Valid PasswordForm passwordForm,
-                                 Errors errors, Model model, RedirectAttributes attributes){
-        if(errors.hasErrors()){
+                                 Errors errors, Model model, RedirectAttributes attributes) {
+        if (errors.hasErrors()) {
             model.addAttribute(account);
             return SETTINGS_PASSWORD_VIEW_NAME;
         }
@@ -99,4 +111,7 @@ public class SettingsController {
         attributes.addFlashAttribute("message", "알림 설정을 변경했습니다.");
         return "redirect:" + SETTINGS_NOTIFICATIONS_URL;
     }
+
+
+
 }

--- a/src/main/java/com/guham/guham/settings/form/NicknameForm.java
+++ b/src/main/java/com/guham/guham/settings/form/NicknameForm.java
@@ -1,15 +1,22 @@
 package com.guham.guham.settings.form;
 
+import com.guham.guham.domain.Account;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
 @Data
+@NoArgsConstructor
 public class NicknameForm {
 
     @NotBlank
     @Length(min = 3, max = 20)
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9_-]{3,20}$")
     private String nickname;
+
+    public NicknameForm(Account account) {
+        this.nickname = account.getNickname();
+    }
 }

--- a/src/main/java/com/guham/guham/settings/form/NicknameForm.java
+++ b/src/main/java/com/guham/guham/settings/form/NicknameForm.java
@@ -1,0 +1,15 @@
+package com.guham.guham.settings.form;
+
+import lombok.Data;
+import org.hibernate.validator.constraints.Length;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Data
+public class NicknameForm {
+
+    @NotBlank
+    @Length(min = 3, max = 20)
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9_-]{3,20}$")
+    private String nickname;
+}

--- a/src/main/java/com/guham/guham/settings/form/Notifications.java
+++ b/src/main/java/com/guham/guham/settings/form/Notifications.java
@@ -1,4 +1,4 @@
-package com.guham.guham.settings;
+package com.guham.guham.settings.form;
 
 import com.guham.guham.domain.Account;
 import lombok.Data;

--- a/src/main/java/com/guham/guham/settings/form/PasswordForm.java
+++ b/src/main/java/com/guham/guham/settings/form/PasswordForm.java
@@ -1,4 +1,4 @@
-package com.guham.guham.settings;
+package com.guham.guham.settings.form;
 
 import lombok.Data;
 import org.hibernate.validator.constraints.Length;

--- a/src/main/java/com/guham/guham/settings/form/Profile.java
+++ b/src/main/java/com/guham/guham/settings/form/Profile.java
@@ -1,4 +1,4 @@
-package com.guham.guham.settings;
+package com.guham.guham.settings.form;
 
 import com.guham.guham.domain.Account;
 import lombok.Data;

--- a/src/main/java/com/guham/guham/settings/form/Profile.java
+++ b/src/main/java/com/guham/guham/settings/form/Profile.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
 @Data
-@NoArgsConstructor
 public class Profile {
     @Length(max = 35)
     private String bio;

--- a/src/main/java/com/guham/guham/settings/validator/NicknameFormValidator.java
+++ b/src/main/java/com/guham/guham/settings/validator/NicknameFormValidator.java
@@ -1,0 +1,31 @@
+package com.guham.guham.settings.validator;
+
+import com.guham.guham.account.AccountRepository;
+import com.guham.guham.domain.Account;
+import com.guham.guham.settings.form.NicknameForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+@Component
+@RequiredArgsConstructor
+public class NicknameFormValidator implements Validator {
+
+
+    private final AccountRepository accountRepository;
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return NicknameForm.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public void validate(Object target, Errors errors) {
+        NicknameForm nicknameForm = (NicknameForm) target;
+        Account byNickname = accountRepository.findByNickname(nicknameForm.getNickname());
+        if(byNickname != null){
+            errors.rejectValue("nickname", "wrong.value",
+                    "입력하신 닉네임을 사용할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/guham/guham/settings/validator/PasswordFormValidator.java
+++ b/src/main/java/com/guham/guham/settings/validator/PasswordFormValidator.java
@@ -1,4 +1,4 @@
-package com.guham.guham.settings;
+package com.guham.guham.settings.validator;
 
 import com.guham.guham.settings.form.PasswordForm;
 import org.springframework.validation.Errors;

--- a/src/main/java/com/guham/guham/settings/validator/PasswordFormValidator.java
+++ b/src/main/java/com/guham/guham/settings/validator/PasswordFormValidator.java
@@ -1,5 +1,6 @@
 package com.guham.guham.settings;
 
+import com.guham.guham.settings.form.PasswordForm;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -54,8 +54,9 @@
            aria-haspopup="true" aria-expanded="false">
           <svg th:if="${#strings.isEmpty(account?.profileImage)}" th:data-jdenticon-value="${#authentication.name}"
                width="24" height="24" class="rounded border bg-light"></svg>
-          <img th:if="${!#strings.isEmpty(account?.profileImage)}" th:src="${account.profileImage}"
+          <img th:if="${!#strings.isEmpty(account?.profileImage)}"  th:src="${account.profileImage}"
                width="24" height="24" class="rounded border"/>
+
         </a>
         <div class="dropdown-menu dropdown-menu-sm-right" aria-labelledby="userDropdown">
           <h6 class="dropdown-header">

--- a/src/main/resources/templates/settings/account.html
+++ b/src/main/resources/templates/settings/account.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head th:replace="fragments::head">
+</head>
+<body class="bg-light">
+<div th:replace="fragments::main-nav"></div>
+
+<div class="container">
+  <div class="row mt-5 justify-content-center">
+    <div class="col-2">
+      <div th:replace="fragments::settings-menu(currentMenu='account')"></div>
+
+    </div>
+    <div class="col-8">
+
+      <div th:if="${message}" class="alert alert-info alert-dismissible fade show mt-3" role="alert">
+        <span th:text="${message}">메시지</span>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+
+      <div class="row">
+        <h2 class="col-12">닉네임 변경</h2>
+      </div>
+      <div class="row">
+        <form class="needs-validation col-12" th:object="${nicknameForm}" th:action="@{/settings/account}" method="post" novalidate>
+          <div class="alert alert-warning" role="alert">
+            닉네임을 변경하면 프로필 페이지 링크도 바뀝니다!
+          </div>
+          <div class="form-group">
+            <input id="nickname" type="text" th:field="*{nickname}" class="form-control" aria-describedby="nicknameHelp" required>
+            <small id="nicknameHelp" class="form-text text-muted">
+              공백없이 문자와 숫자로만 3자 이상 20자 이내로 입력하세요. 가입후에 변경할 수 있습니다.
+            </small>
+            <small class="invalid-feedback">닉네임을 입력하세요.</small>
+            <small class="form-text text-danger" th:if="${#fields.hasErrors('nickname')}" th:errors="*{nickname}">nickname Error</small>
+          </div>
+          <div class="form-group">
+            <button class="btn btn-outline-primary" type="submit" aria-describedby="submitHelp">변경하기</button>
+          </div>
+        </form>
+      </div>
+      <div class="dropdown-divider"></div>
+      <div class="row">
+        <div class="col-sm-12">
+          <h2 class="text-danger">계정 삭제</h2>
+          <div class="alert alert-danger" role="alert">
+            이 계정은 삭제할 수 없습니다.
+          </div>
+          <button class="btn btn-outline-danger disabled">계정 삭제</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div th:replace="fragments.html :: footer"></div>
+</div>
+<script th:replace="fragments.html :: form-validation"></script>
+</body>
+</html>

--- a/src/main/resources/templates/settings/profile.html
+++ b/src/main/resources/templates/settings/profile.html
@@ -40,7 +40,7 @@
           <div class="form-group">
             <label for="url">링크</label>
             <input id="url" type="url" th:field="*{url}" class="form-control"
-                   placeholder="http://studyolle.com" aria-describedby="urlHelp" required>
+                   placeholder="http://teamGuham.com" aria-describedby="urlHelp" required>
             <small id="urlHelp" class="form-text text-muted">
               블로그, 유튜브 또는 포트폴리오나 좋아하는 웹 사이트 등 본인을 표현할 수 있는 링크를 추가하세요.
             </small>

--- a/src/test/java/com/guham/guham/settings/SettingsControllerTest.java
+++ b/src/test/java/com/guham/guham/settings/SettingsControllerTest.java
@@ -3,22 +3,15 @@ package com.guham.guham.settings;
 import com.guham.guham.WithAccount;
 import com.guham.guham.account.AccountRepository;
 import com.guham.guham.account.AccountService;
-import com.guham.guham.account.SignUpForm;
 import com.guham.guham.domain.Account;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.test.context.support.TestExecutionEvent;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Set;
 
 import static com.guham.guham.settings.SettingsController.*;
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
기능구현
1. NicknameForm, 중복검사를 위한 NicknameFormValidator 구현
2. Account UpdateNickname 구현
3. Account Service, SettingsController 구현
4. SettingController NicknameFormValidator 주입
5. settings/account View 구현
6. Detached Entity 업데이트 시 Security Context와 DB정보 동기화

블로그 정리
[Security Context 유저 정보와 DB 유저 정보 동기화](https://anythingis.tistory.com/151)
[View에서 접근 가능한 유저정보를 컨트롤러에서 Model로 넘겨주는 이유](https://anythingis.tistory.com/152)

